### PR TITLE
fix: add style.css, move logic to server & other fix

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,31 +1,14 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>The Amazing Chat</title>
-
-    <link rel="shortcut icon" href="https://material.io/static/images/simple-lp/favicons/components-72x72.png">
-    <link rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/normalize/6.0.0/normalize.min.css">
+    <base href="/">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/normalize/6.0.0/normalize.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet">
-    <style>
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-        body { font: 13px Roboto, Helvetica, Arial; }
-        header { text-align: center; font-size: 18px; font-weight: 700; background: lightcyan; padding: 10px;}
-        p { text-align: center; }
-        #list { width: 30%; background: darkcyan; color: white; padding: 10px; position: fixed; bottom: 0;}
-        #list p { font-size: 18px; font-weight: 700; margin-bottom: 10px }
-        #list #users { list-style-type: none; }
-        #list #users li { padding-bottom: 4px; }
-        #chat { width: 70%; position: fixed; bottom: 0; right: 0; background: lightcyan; padding: 20px;}
-        #messages { list-style-type: none; margin: 0; padding: 0; max-height: 250px; overflow: auto; }
-        #messages li { padding: 5px 10px; }
-        form {  padding: 3px; width: 100%; }
-        form input { border: 0; padding: 10px; width: 80%; margin-right: .5%; }
-        form button { width: 19%; background: rgb(56, 224, 255); border: none; padding: 10px; }
-    </style>
+    <link href="/style.css" type="text/css" rel="stylesheet">
 </head>
 <body>
 <section>
@@ -54,14 +37,21 @@
 <script src="https://code.jquery.com/jquery-1.11.1.js"></script>
 <script>
     $(function () {
-        $('#messages').change(function () {
-                $('#messages').animate({ scrollTop: $('#messages').height() }, 300);
-            }
-        );
-
         let socket = io();
         let currentUser;
         let connectedUsers;
+        let message = $('#msg');
+        let messagesSelector = $('#messages');
+        let usersSelector = $('#users');
+
+        messagesSelector.change(function () {
+            messagesSelector.animate({ scrollTop: messagesSelector.height() }, 300);
+            }
+        );
+        usersSelector.change(function () {
+            usersSelector.animate({ scrollTop: usersSelector.height() }, 300);
+            }
+        );
 
         socket.on('connection', function(user){
             $('#user').text(user.Username);
@@ -71,53 +61,30 @@
         });
         $('form').submit(function(e){
             e.preventDefault();
-            let msg = { author: currentUser.Username, content: $('#msg').val(), colour: currentUser.Colour };
-
-            if (msg.content.startsWith('/whoami')) {
-                $('#messages').append($('<li>').text('You are ' + currentUser.Username).css({ "background-color": "lightgrey", "border-left": "5px solid #ccc" })).trigger('change');
-                $('#msg').val('');
-                return false;
-            }
-            if (msg.content.startsWith('/date')) {
-                let date = new Date().toLocaleDateString();
-                $('#messages').append($('<li>').text('The current date is ' + date).css({ "background-color": "lightgrey", "border-left": "5px solid #ccc" })).trigger('change');
-                $('#msg').val('');
-                return false;
-            }
-            if (msg.content.startsWith('/ping')) {
-                socket.emit("user ping");
-                $('#msg').val('');
-                return false;
-            }
-            if (msg.content.startsWith('@')) {
-                let sender = msg.content.split(" ")[0].replace("@", "");
-                let content = msg.content.replace("@"+sender, "");
-                if (jQuery.inArray(sender, connectedUsers)!=='-1') {
-                    socket.emit('private message', sender, content);
-                }
-            } else {
-                socket.emit("message", msg);
-            }
-
-            $('#msg').val('');
+            let msg = { author: currentUser.Username, content: message.val(), colour: currentUser.Colour };
+            socket.emit("message", msg);
+            message.val('');
             return false;
         });
         socket.on('message', function(msg){
-            $('#messages').append($('<li>').text(msg.author + ' said: ' + msg.content).css({ "background-color": msg.colour, "border-left": "5px solid #ccc" })).trigger('change');
+            messagesSelector.append($('<li>').text(msg.author + ' said: ' + msg.content).css({ "background-color": msg.colour, "border-left": "5px solid #ccc" })).trigger('change');
+        });
+        socket.on('internal message', function(msg){
+            messagesSelector.append($('<li>').text(msg).css({ "background-color": "lightgrey", "border-left": "5px solid #ccc" })).trigger('change');
         });
         socket.on('edit users', function(users){
             $('#count').html(users.length);
             for (let user of users) {
-                $('#users').append($('<li>').text(user.Username));
+                usersSelector.append($('<li>').text(user.Username)).trigger('change');
             }
             connectedUsers = users;
         });
         socket.on('private message received', function (sender, msg){
-            $('#messages').append($('<li>').text(sender + ' (privately) said: ' + msg).css({ "background-color": "coral", "border-left": "5px solid #ccc" })).trigger('change');
+            messagesSelector.append($('<li>').text(sender + ' (privately) said: ' + msg).css({ "background-color": "coral", "border-left": "5px solid #ccc" })).trigger('change');
         });
         socket.on('ping received', function(msg){
             alert(msg);
-            $('#messages').append($('<li>').text('Server said: ' + msg).css({ "background-color": "lightgrey", "border-left": "5px solid #ccc" })).trigger('change');
+            messagesSelector.append($('<li>').text('Server said: ' + msg).css({ "background-color": "lightgrey", "border-left": "5px solid #ccc" })).trigger('change');
         });
     });
 </script>

--- a/public/index.html
+++ b/public/index.html
@@ -61,9 +61,11 @@
         });
         $('form').submit(function(e){
             e.preventDefault();
-            let msg = { author: currentUser.Username, content: message.val(), colour: currentUser.Colour };
-            socket.emit("message", msg);
-            message.val('');
+            if (message.val().trim().length >= 1) {
+                let msg = { author: currentUser.Username, content: message.val(), colour: currentUser.Colour };
+                socket.emit("message", msg);
+                message.val('');
+            }
             return false;
         });
         socket.on('message', function(msg){
@@ -73,6 +75,7 @@
             messagesSelector.append($('<li>').text(msg).css({ "background-color": "lightgrey", "border-left": "5px solid #ccc" })).trigger('change');
         });
         socket.on('edit users', function(users){
+            usersSelector.html('');
             $('#count').html(users.length);
             for (let user of users) {
                 usersSelector.append($('<li>').text(user.Username)).trigger('change');
@@ -81,6 +84,12 @@
         });
         socket.on('private message received', function (sender, msg){
             messagesSelector.append($('<li>').text(sender + ' (privately) said: ' + msg).css({ "background-color": "coral", "border-left": "5px solid #ccc" })).trigger('change');
+        });
+        socket.on('private message sent', function (receiver, msg){
+            messagesSelector.append($('<li>').text( '(To ' + receiver +') You said: ' + msg).css({ "background-color": "coral", "border-left": "5px solid #ccc" })).trigger('change');
+        });
+        socket.on('self message sent', function (receiver, msg){
+            messagesSelector.append($('<li>').text( 'You said to yourself: ' + msg).css({ "background-color": "lightblue", "border-left": "5px solid #ccc" })).trigger('change');
         });
         socket.on('ping received', function(msg){
             alert(msg);

--- a/public/style.css
+++ b/public/style.css
@@ -1,4 +1,3 @@
-
 * {
     margin: 0;
     padding: 0;
@@ -9,35 +8,77 @@ body {
     font: 13px Roboto, Helvetica, Arial;
 }
 
+header {
+    text-align: center;
+    font-size: 18px;
+    font-weight: 700;
+    background: lightcyan;
+    padding: 10px;
+}
 
-form {
-    background: #000;
-    padding: 3px;
+p {
+    text-align: center;
+}
+
+#list {
+    width: 30%;
+    background: darkcyan;
+    color: white;
+    padding: 10px;
     position: fixed;
     bottom: 0;
-    width: 100%;
 }
 
-form input {
-    border: 0;
-    padding: 10px;
-    width: 90%;
-    margin-right: .5%;
+#list p {
+    font-size: 18px;
+    font-weight: 700;
+    margin-bottom: 10px
 }
 
-form button {
-    width: 9%;
-    background: rgb(130, 224, 255);
-    border: none;
-    padding: 10px;
+#list #users {
+    list-style-type: none;
+}
+
+#list #users li {
+    padding-bottom: 4px;
+}
+
+#chat {
+    width: 70%;
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    background: lightcyan;
+    padding: 20px;
 }
 
 #messages {
     list-style-type: none;
     margin: 0;
     padding: 0;
+    max-height: 250px;
+    overflow: auto;
 }
 
 #messages li {
     padding: 5px 10px;
+}
+
+form {
+    padding: 3px;
+    width: 100%;
+}
+
+form input {
+    border: 0;
+    padding: 10px;
+    width: 80%;
+    margin-right: .5%;
+}
+
+form button {
+    width: 19%;
+    background: rgb(56, 224, 255);
+    border: none;
+    padding: 10px;
 }


### PR DESCRIPTION
### FIX
**Structure du code :**

- [x] Il serait préférable de dissocier le code Javascript et le code CSS du fichier index.html
- [x]  Le code d'insertion de message revient de trop nombreuses fois dans le front : `$('#messages').append($('<li>')`

**Messages :**
- [x] Il est possible d'envoyer des messages vides

**Messages privés :**
- [x] La personne qui reçoit le message ne voit pas le bon pseudo de l'expéditeur
- [x] Il faudrait pouvoir voir les messages qu'on a envoyé à d'autres
- [x]  Il faudrait pouvoir envoyer des messages à soi-même
- [x] La logique d'envoi d'un message privé se trouve côté front (ce qui peut poser souci si la liste des utilisateurs connectés n'est pas bien synchronisée)

**Utilisateurs connectés :**
- [x] Les utilisateurs qui se déconnectent restent présents dans la liste des utilisateurs connectés (actualiser plusieurs fois la page permet de s'en rendre compte)
- [x] Si dans une fenêtre (1) on se rend sur le tchat, et qu'on ouvre le tchat dans une nouvelle fenêtre (2), la fenêtre 1 ne reçoit pas systématiquement l'information qu'un nouvel utilisateur s'est connecté
- [x]  Lorsque cette liste est très longue, elle prend toute la hauteur de la fenêtre et n'est pas scrollable (contrairement aux messages)

**Autres :**
- [x]  Il serait préférable de gérer les commandes spéciales /whoami, /date, etc. côté serveur pour simplifier le code côté front
